### PR TITLE
Fix namespaces trigger recreation for dependents 

### DIFF
--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -354,7 +354,7 @@ module Scenic
             create_view view.name, view.definition
           end
 
-          lost_triggers = triggers.select {|t| t.table == view.name }
+          lost_triggers = triggers.select {|t| t.table == view.name.split('.').last }
           lost_triggers.each{|trigger| trigger_reapplier.try_trigger_create  trigger}
         end
       end

--- a/lib/scenic/adapters/postgres/trigger_reapplication.rb
+++ b/lib/scenic/adapters/postgres/trigger_reapplication.rb
@@ -37,9 +37,9 @@ module Scenic
           end
 
           if success
-            say "trigger '#{trigger.name}' on '#{trigger.table}' has been recreated"
+            say "trigger '#{trigger.name}' on '#{trigger.namespace}.#{trigger.table}' has been recreated"
           else
-            say "trigger '#{trigger.name}' on '#{trigger.table}' is no longer valid and has been dropped."
+            say "trigger '#{trigger.name}' on '#{trigger.namespace}.#{trigger.table}' is no longer valid and has been dropped."
           end
         end
 

--- a/lib/scenic/adapters/postgres/triggers.rb
+++ b/lib/scenic/adapters/postgres/triggers.rb
@@ -29,6 +29,7 @@ module Scenic
 			action_orientation, action_timing
 			FROM information_schema.triggers
 			WHERE event_object_table = '#{name}'
+			AND event_object_schema = ANY (current_schemas(false))
 			GROUP BY event_object_table,
 			trigger_name, action_statement,
 			action_orientation, action_timing

--- a/lib/scenic/adapters/trigger.rb
+++ b/lib/scenic/adapters/trigger.rb
@@ -1,1 +1,0 @@
-trigger.rb

--- a/lib/scenic/trigger.rb
+++ b/lib/scenic/trigger.rb
@@ -8,20 +8,21 @@ module Scenic
   # @api extension
   class Trigger
 
-  	attr_reader :event, :table, :name, :action, :scope, :timing
+  	attr_reader :event, :namespace, :table, :name, :action, :scope, :timing
 
   	def definition
   	<<-DDL
   	  CREATE TRIGGER #{name}
   	  #{@timing} #{@event}
-  	  ON #{@table}
+  	  ON "#{@namespace}".#{@table}
   	  FOR EACH #{@scope}
   	  #{@action};
   	DDL
   	end
 
-    def initialize(event:, table:, name:, action:, scope:, timing:)
+    def initialize(event:, namespace:, table:, name:, action:, scope:, timing:)
       @event = event
+      @namespace = namespace
       @table = table
       @name  = name
       @action = action


### PR DESCRIPTION
Views come back namespaced from the selection query, while they're compared as the bare, non-namedspaced versions. This was fixed earlier to recreate dependent views, but I missed doing it for the triggers. 